### PR TITLE
[PLOP-5362] refactor: rename workflows

### DIFF
--- a/.github/workflows/goldeneye.yml
+++ b/.github/workflows/goldeneye.yml
@@ -24,9 +24,9 @@ on:
         required: true
 
 jobs:
-  execute:
+  deploy:
     runs-on: ubuntu-22.04
-    name: Execute
+    name: Deploy
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,9 +20,9 @@ on:
         required: true
 
 jobs:
-  execute:
+  lint:
     runs-on: ubuntu-22.04
-    name: Execute
+    name: Lint
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## What change(s) does your PR add?
Renames the workflows since GitHub names both of these as `Reusable Workflow / Execute` so we can't distinguish between them despite having distinct names for them in the parent workflows. This is needed so that GoldenEye can enforce linting when needed.

## How did you test your change(s)?
Tested with studyportals/meta-ranking-clone#122

## What do you want feedback on?
Do you want different names?
