### PR TITLE
[PLOP-7203]  Revert "Use Github federation"

### DIFF
--- a/.github/workflows/goldeneye.yml
+++ b/.github/workflows/goldeneye.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       aws-region:
         required: false
-        default: eu-west-1
+        default: eu-central-1
         type: string
       descriptor:
         required: false
@@ -15,28 +15,29 @@ on:
         required: false
         default: latest
         type: string
+    secrets:
+      aws-access-key-id:
+        required: true
+      aws-secret-access-key:
+        required: true
+      token:
+        required: true
 
 jobs:
   deploy:
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
-      contents: read
-      issues: read
-      pull-requests: read
     name: Deploy
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+    - uses: aws-actions/configure-aws-credentials@v1
       with:
-        role-to-assume: arn:aws:iam::915473064509:role/GoldenEye-Github
-        role-session-name: goldeneye-federation
+        aws-access-key-id: ${{ secrets.aws-access-key-id }}
         aws-region: ${{ inputs.aws-region }}
+        aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
     - uses: docker://studyportals/goldeneye:latest
       with:
         descriptor: ${{ inputs.descriptor }}
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.token }}
 


### PR DESCRIPTION
Reverts studyportals/.github#7

Apparently the workflows needs to be updated as well to avoid sending params that are no longer supported :-| 