### PR TITLE
Superlinter latest version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,6 @@ jobs:
           fi
         if: inputs.validate-php-phpmd
       - run: cat .github/super-linter.env >> "$GITHUB_ENV"
-      - uses: super-linter/super-linter/slim@v8.5.0
+      - uses: super-linter/super-linter/slim@v8.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,40 +25,40 @@ jobs:
     name: Lint
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
-    - id: files
-      uses: studyportals/get-changed-files@main
-      with:
-        token: ${{ secrets.token }}
-        format: csv
-        extensions: ".php"
-      if: inputs.validate-php-phpmd
-    - uses: actions/setup-node@v4
-      with:
-        node-version: ${{ inputs.node-version }}
-    - uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ inputs.php-version }}
-      if: inputs.validate-php-phpmd
-    - run: npm install @studyportals/code-style@$(jq -r '.devDependencies."@studyportals/code-style"' package.json) --no-save --omit=optional
-      env:
-        CYPRESS_INSTALL_BINARY: 0
-    - run: |
-        composer config github-oauth.github.com ${{ secrets.token }}
-        npm run configure || true
-        composer require --dev phpmd/phpmd:$(jq -r '."require-dev"."phpmd/phpmd"' composer.json)
-      env:
-        GITHUB_TOKEN: ${{ secrets.token }}
-      if: inputs.validate-php-phpmd
-    - run: |
-        if [ ! -z "${{ steps.files.outputs.added_modified_renamed }}" ]; then
-          echo "linting changed files..."
-          ./vendor/bin/phpmd ${{ steps.files.outputs.added_modified_renamed }} text phpmd.xml
-        fi
-      if: inputs.validate-php-phpmd
-    - run: cat .github/super-linter.env >> "$GITHUB_ENV"
-    - uses: super-linter/super-linter/slim@v6.8.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.token }}
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - id: files
+        uses: studyportals/get-changed-files@main
+        with:
+          token: ${{ secrets.token }}
+          format: csv
+          extensions: ".php"
+        if: inputs.validate-php-phpmd
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+        if: inputs.validate-php-phpmd
+      - run: npm install @studyportals/code-style@$(jq -r '.devDependencies."@studyportals/code-style"' package.json) --no-save --omit=optional
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+      - run: |
+          composer config github-oauth.github.com ${{ secrets.token }}
+          npm run configure || true
+          composer require --dev phpmd/phpmd:$(jq -r '."require-dev"."phpmd/phpmd"' composer.json)
+        env:
+          GITHUB_TOKEN: ${{ secrets.token }}
+        if: inputs.validate-php-phpmd
+      - run: |
+          if [ ! -z "${{ steps.files.outputs.added_modified_renamed }}" ]; then
+            echo "linting changed files..."
+            ./vendor/bin/phpmd ${{ steps.files.outputs.added_modified_renamed }} text phpmd.xml
+          fi
+        if: inputs.validate-php-phpmd
+      - run: cat .github/super-linter.env >> "$GITHUB_ENV"
+      - uses: super-linter/super-linter/slim@v8.5.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.token }}
 
       - run: |
-          if [ ! -f "/github/workspace/vendor/bin/phpmd" ]; then
+          if [ ! -d "/github/workspace/vendor/phpmd/phpmd" ]; then
             composer require --dev phpmd/phpmd:$(jq -r '."require-dev"."phpmd/phpmd"' composer.json)
           fi
           composer run phpmd

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,6 @@ jobs:
           fi
         if: inputs.validate-php-phpmd
       - run: cat .github/super-linter.env >> "$GITHUB_ENV"
-      - uses: super-linter/super-linter/slim@v8.4.0
+      - uses: super-linter/super-linter/slim@v8.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.token }}
 
       - run: |
-          composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+          composer install --no-progress --prefer-dist
         if: inputs.validate-php-phpmd || inputs.validate-php-phpstan
 
       - run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,6 @@ on:
     secrets:
       token:
         required: true
-
 jobs:
   lint:
     runs-on: ubuntu-22.04
@@ -28,6 +27,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
       - id: files
         uses: studyportals/get-changed-files@main
         with:
@@ -35,16 +35,26 @@ jobs:
           format: csv
           extensions: ".php"
         if: inputs.validate-php-phpmd
+
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
+
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.php-version }}
         if: inputs.validate-php-phpmd
+
       - run: npm install @studyportals/code-style@$(jq -r '.devDependencies."@studyportals/code-style"' package.json) --no-save --omit=optional
         env:
           CYPRESS_INSTALL_BINARY: 0
+
+      - run: cat .github/super-linter.env >> "$GITHUB_ENV"
+
+      - uses: super-linter/super-linter/slim@v8.5.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.token }}
+
       - run: |
           composer config github-oauth.github.com ${{ secrets.token }}
           npm run configure || true
@@ -52,13 +62,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.token }}
         if: inputs.validate-php-phpmd
+
       - run: |
           if [ ! -z "${{ steps.files.outputs.added_modified_renamed }}" ]; then
             echo "linting changed files..."
             ./vendor/bin/phpmd ${{ steps.files.outputs.added_modified_renamed }} text phpmd.xml
           fi
         if: inputs.validate-php-phpmd
-      - run: cat .github/super-linter.env >> "$GITHUB_ENV"
-      - uses: super-linter/super-linter/slim@v8.5.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,15 +63,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.token }}
 
       - run: |
-          composer install --no-progress --prefer-dist
+          composer install --no-progress --dev
         if: inputs.validate-php-phpmd || inputs.validate-php-phpstan
 
       - run: |
-          echo "running phpmd..."
           composer run phpmd
         if: inputs.validate-php-phpmd
 
       - run: |
-          echo "running phpstan..."
           composer run phpstan
         if: inputs.validate-php-phpstan

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,6 @@ jobs:
           fi
         if: inputs.validate-php-phpmd
       - run: cat .github/super-linter.env >> "$GITHUB_ENV"
-      - uses: super-linter/super-linter/slim@v7.4.0
+      - uses: super-linter/super-linter/slim@v7.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,8 +52,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.token }}
 
       - run: |
-          if [ ! -d "/github/workspace/vendor/phpmd/phpmd" ]; then
-            composer require --dev phpmd/phpmd:$(jq -r '."require-dev"."phpmd/phpmd"' composer.json)
+          if [ ! -x "${GITHUB_WORKSPACE}/vendor/bin/phpmd" ]; then
+            composer install
           fi
           composer run phpmd
         if: inputs.validate-php-phpmd

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,6 @@ on:
         required: false
         default: false
         type: boolean
-      validate-php-phpstan:
-        required: false
-        default: false
-        type: boolean
     secrets:
       token:
         required: true
@@ -31,14 +27,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - id: files
-        uses: studyportals/get-changed-files@main
-        with:
-          token: ${{ secrets.token }}
-          format: csv
-          extensions: ".php"
-        if: inputs.validate-php-phpmd
 
       - uses: actions/setup-node@v4
         with:
@@ -65,7 +53,3 @@ jobs:
       - run: |
           composer run phpmd
         if: inputs.validate-php-phpmd
-
-      - run: |
-          composer run phpstan
-        if: inputs.validate-php-phpstan

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,6 +67,6 @@ jobs:
       - run: |
           if [ ! -z "${{ steps.files.outputs.added_modified_renamed }}" ]; then
             echo "linting changed files..."
-            ./vendor/bin/phpmd ${{ steps.files.outputs.added_modified_renamed }} text phpmd.xml
+            /github/workspace/vendor/bin/phpmd ${{ steps.files.outputs.added_modified_renamed }} text phpmd.xml
           fi
         if: inputs.validate-php-phpmd

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,10 +63,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.token }}
 
       - run: |
-          composer install --no-progress --dev
-        if: inputs.validate-php-phpmd || inputs.validate-php-phpstan
-
-      - run: |
           composer run phpmd
         if: inputs.validate-php-phpmd
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,10 +63,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.token }}
 
       - run: |
-          composer require --dev phpmd/phpmd:$(jq -r '."require-dev"."phpmd/phpmd"' composer.json)
-        env:
-          GITHUB_TOKEN: ${{ secrets.token }}
-        if: inputs.validate-php-phpmd
+          composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+        if: inputs.validate-php-phpmd || inputs.validate-php-phpstan
 
       - run: |
           echo "running phpmd..."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,6 @@ jobs:
           fi
         if: inputs.validate-php-phpmd
       - run: cat .github/super-linter.env >> "$GITHUB_ENV"
-      - uses: super-linter/super-linter/slim@v8.3.2
+      - uses: super-linter/super-linter/slim@v7.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,6 @@ jobs:
           fi
         if: inputs.validate-php-phpmd
       - run: cat .github/super-linter.env >> "$GITHUB_ENV"
-      - uses: super-linter/super-linter/slim@v8.5.0
+      - uses: super-linter/super-linter/slim@v7.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,6 @@ jobs:
           fi
         if: inputs.validate-php-phpmd
       - run: cat .github/super-linter.env >> "$GITHUB_ENV"
-      - uses: super-linter/super-linter/slim@v7.4.0
+      - uses: super-linter/super-linter/slim@v8.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,6 @@ jobs:
           fi
         if: inputs.validate-php-phpmd
       - run: cat .github/super-linter.env >> "$GITHUB_ENV"
-      - uses: super-linter/super-linter/slim@v7.2.1
+      - uses: super-linter/super-linter/slim@v8.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
     name: Lint
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,5 +52,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.token }}
 
       - run: |
+          if [ ! -f "/github/workspace/vendor/bin/phpmd" ]; then
+            composer require --dev phpmd/phpmd:$(jq -r '."require-dev"."phpmd/phpmd"' composer.json)
+          fi
           composer run phpmd
         if: inputs.validate-php-phpmd

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,10 @@ on:
         required: false
         default: false
         type: boolean
+      validate-php-phpstan:
+        required: false
+        default: false
+        type: boolean
     secrets:
       token:
         required: true
@@ -65,8 +69,11 @@ jobs:
         if: inputs.validate-php-phpmd
 
       - run: |
-          if [ ! -z "${{ steps.files.outputs.added_modified_renamed }}" ]; then
-            echo "linting changed files..."
-            /github/workspace/vendor/bin/phpmd ${{ steps.files.outputs.added_modified_renamed }} text phpmd.xml
-          fi
+          echo "running phpmd..."
+          composer run phpmd
         if: inputs.validate-php-phpmd
+
+      - run: |
+          echo "running phpstan..."
+          composer run phpstan
+        if: inputs.validate-php-phpstan

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ on:
         required: true
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Lint
     timeout-minutes: 30
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,7 @@ jobs:
 
       - run: |
           composer config github-oauth.github.com ${{ secrets.token }}
+          npm run configure || true
 
       - uses: super-linter/super-linter/slim@v8.5.0
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,13 +51,14 @@ jobs:
 
       - run: cat .github/super-linter.env >> "$GITHUB_ENV"
 
+      - run: |
+          composer config github-oauth.github.com ${{ secrets.token }}
+
       - uses: super-linter/super-linter/slim@v8.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.token }}
 
       - run: |
-          composer config github-oauth.github.com ${{ secrets.token }}
-          npm run configure || true
           composer require --dev phpmd/phpmd:$(jq -r '."require-dev"."phpmd/phpmd"' composer.json)
         env:
           GITHUB_TOKEN: ${{ secrets.token }}


### PR DESCRIPTION
## What change(s) does your PR add?
Currently, we are using `super-linter/super-linter/slim@v6.8.0` in our linter workflow which by default includes PHP 8.3 and outdated `PHPStan - PHP Static Analysis Tool 1.11.2` version.

With PHP 8.4 Upgrade in Domain API we need to rely on PHP 8.4 and `PHPStan - PHP Static Analysis Tool 2.1.49`. To accommodate these versions, this PR changes super-linter version to the latest which has PHP 8.4 and `PHPStan - PHP Static Analysis Tool 2.1.37` support.

The order of the linter runners is also changed. Previously we were running PHPMD in the first place with only the changed files. However, we already fixed existing issues in the repositories, so there is no longer an issue to run in the entire codebase. We expect to have a `phpmd` script available in the composer.json.

We need to run the super-linter first, because it is looking for composer files recursively in the workspace. And it tries to install composer files within the vendor directory if the composer is already run.

## How did you test your change(s)?
Tested on Domain API PRs.

## What do you want feedback on?
This change will lead us to update the linter workflows in all repositories. Do you think it is a problem?


## Relevant contextual information?
_e.g. documentation/diagrams_
